### PR TITLE
Use time.time rather than time.clock to get current packet time

### DIFF
--- a/SnifferAPI/CaptureFiles.py
+++ b/SnifferAPI/CaptureFiles.py
@@ -97,7 +97,7 @@ class CaptureFileHandler:
                 
     def makePacketHeader(self, length):
         
-        timeNow = time.clock()
+        timeNow = time.time()
         
         TS_SEC         = int(timeNow)
         TS_USEC     = int((timeNow-TS_SEC)*1000000)


### PR DESCRIPTION
The time.clock function returns the CPU time used by the process,
rather than the current system time.  To get the system time
(which is what we want to put in the pcap file) use the time.time()
function instead.
