### PR TITLE
Add pipe argument

### DIFF
--- a/PcapPipe.py
+++ b/PcapPipe.py
@@ -1,0 +1,129 @@
+#via https://github.com/cdealti/Adafruit_BLESniffer_Python
+
+import logging
+import os
+import sys
+import time
+
+"""
+PcapPipe.py: an Unix named pipe where PCAP packets are written.
+This pipe represents the interface between the sniffer and Wireshark.
+The original code has been posted on the Nordic Developer Zone [1][2] by
+a Nordic employee and is not accompanied by a license.
+
+[1] https://devzone.nordicsemi.com/blogs/750/ble-sniffer-in-linux-using-wireshark
+[2] https://devzone.nordicsemi.com/attachment/74532982f9e4b627b4cddfec2cb585e7
+"""
+
+__author__    = "Stian"
+__copyright__ = "Copyright (c) 2014, Nordic Semiconductor ASA"
+__license__   = "MIT"
+__version__   = "0.1.0"
+
+class PcapPipe(object):
+    def open_and_init(self, pipeFilePath):
+        try:
+            os.mkfifo(pipeFilePath)
+        except OSError:
+            logging.warn("fifo already exists?")
+            raise SystemExit(1)
+        self._pipe = open(pipeFilePath, 'w')
+        self.write(self.makeGlobalHeader())
+
+    def write(self, message):
+        if not self._pipe: return
+        try:
+            self._pipe.write(''.join(map(chr, message)))
+            self._pipe.flush()
+        except IOError:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            logging.error('Got exception trying to write to pipe: %s', exc_value)
+            self.close()
+
+    def close(self):
+        logging.debug("closing pipe")
+        if not self._pipe: return
+        self._pipe.close()
+        self._pipe = None
+
+    def isOpen(self):
+        return self._pipe is not None and not self._pipe.closed 
+
+    def newBlePacket(self, notification):
+        packet      = notification.msg["packet"]
+        packetList  = packet.getList()
+        snifferList = self.makePacketHeader(len(packetList) + 1) + [packet.boardId] + packetList
+        self.write(snifferList)
+
+    def makeGlobalHeader(self):
+        LINKTYPE_BLUETOOTH_LE_LL    = 251
+        LINKTYPE_NORDIC_BLE         = 157
+
+        MAGIC_NUMBER                = 0xa1b2c3d4
+        VERSION_MAJOR               = 2
+        VERSION_MINOR               = 4
+        THISZONE                    = 0
+        SIGFIGS                     = 0
+        SNAPLEN                     = 0xFFFF
+        NETWORK                     = LINKTYPE_NORDIC_BLE
+
+        headerString = [
+                            ((MAGIC_NUMBER  >>  0) & 0xFF),
+                            ((MAGIC_NUMBER  >>  8) & 0xFF),
+                            ((MAGIC_NUMBER  >> 16) & 0xFF),
+                            ((MAGIC_NUMBER  >> 24) & 0xFF),
+                            ((VERSION_MAJOR >>  0) & 0xFF),
+                            ((VERSION_MAJOR >>  8) & 0xFF),
+                            ((VERSION_MINOR >>  0) & 0xFF),
+                            ((VERSION_MINOR >>  8) & 0xFF),
+                            ((THISZONE      >>  0) & 0xFF),
+                            ((THISZONE      >>  8) & 0xFF),
+                            ((THISZONE      >> 16) & 0xFF),
+                            ((THISZONE      >> 24) & 0xFF),
+                            ((SIGFIGS       >>  0) & 0xFF),
+                            ((SIGFIGS       >>  8) & 0xFF),
+                            ((SIGFIGS       >> 16) & 0xFF),
+                            ((SIGFIGS       >> 24) & 0xFF),
+                            ((SNAPLEN       >>  0) & 0xFF),
+                            ((SNAPLEN       >>  8) & 0xFF),
+                            ((SNAPLEN       >> 16) & 0xFF),
+                            ((SNAPLEN       >> 24) & 0xFF),
+                            ((NETWORK       >>  0) & 0xFF),
+                            ((NETWORK       >>  8) & 0xFF),
+                            ((NETWORK       >> 16) & 0xFF),
+                            ((NETWORK       >> 24) & 0xFF)
+                        ]
+
+        return headerString
+
+    def makePacketHeader(self, length):
+
+        if(os.name == 'posix'):
+            timeNow = time.time()
+        else:
+            timeNow = time.clock()
+
+        TS_SEC      = int(timeNow)
+        TS_USEC     = int((timeNow-TS_SEC)*1000000)
+        INCL_LENGTH = length
+        ORIG_LENGTH = length
+
+        headerString = [
+                            ((TS_SEC        >>  0) & 0xFF),
+                            ((TS_SEC        >>  8) & 0xFF),
+                            ((TS_SEC        >> 16) & 0xFF),
+                            ((TS_SEC        >> 24) & 0xFF),
+                            ((TS_USEC       >>  0) & 0xFF),
+                            ((TS_USEC       >>  8) & 0xFF),
+                            ((TS_USEC       >> 16) & 0xFF),
+                            ((TS_USEC       >> 24) & 0xFF),
+                            ((INCL_LENGTH   >>  0) & 0xFF),
+                            ((INCL_LENGTH   >>  8) & 0xFF),
+                            ((INCL_LENGTH   >> 16) & 0xFF),
+                            ((INCL_LENGTH   >> 24) & 0xFF),
+                            ((ORIG_LENGTH   >>  0) & 0xFF),
+                            ((ORIG_LENGTH   >>  8) & 0xFF),
+                            ((ORIG_LENGTH   >> 16) & 0xFF),
+                            ((ORIG_LENGTH   >> 24) & 0xFF)
+                        ]
+        return headerString

--- a/sniffer.py
+++ b/sniffer.py
@@ -7,6 +7,8 @@ import os
 import sys
 import time
 import argparse
+import logging
+from sys import platform
 
 from SnifferAPI import Logger
 from SnifferAPI import Sniffer
@@ -181,6 +183,11 @@ if __name__ == '__main__':
 
     # Parser the arguments passed in from the command-line
     args = argparser.parse_args()
+
+    if args.pipe:
+        if not (platform.startswith('linux') or platform == "darwin"):
+            print "Pipes only available on MacOS and Linux"
+            sys.exit(-1)
 
     # Display the libpcap logfile location
     print "Capturing data to " + args.logfile

--- a/sniffer.py
+++ b/sniffer.py
@@ -94,22 +94,32 @@ def selectDevice(devlist):
             # This will start a new scan
             return None
 
+def loop():
+    """Main loop printing some useful statistics"""
+    nLoops = 0
+    nPackets = 0
+    connected = False
 
-def dumpPackets():
-    """Dumps incoming packets to the display"""
-    # Get (pop) unprocessed BLE packets.
-    packets = mySniffer.getPackets()
-    # Display the packets on the screen in verbose mode
-    if args.verbose:
-        for packet in packets:
-            if packet.blePacket is not None:
-                # Display the raw BLE packet payload
-                # Note: 'BlePacket' is nested inside the higher level 'Packet' wrapper class
-                print packet.blePacket.payload
-            else:
-                print packet
-    else:
-        print '.' * len(packets)
+    while True:
+        time.sleep(0.1)
+
+        packets   = mySniffer.getPackets()
+        nLoops   += 1
+        nPackets += len(packets)
+
+        if args.verbose:
+            for packet in packets:
+                if packet.blePacket is not None:
+                    # Display the raw BLE packet payload
+                    # Note: 'BlePacket' is nested inside the higher level 'Packet' wrapper class
+                    print packet.blePacket.payload
+                else:
+                    print packet
+        else:
+            if connected != mySniffer.inConnection or nLoops % 20 == 0:
+                connected = mySniffer.inConnection
+                print "\rconnected: {}, packets: {}, missed: {}".format(mySniffer.inConnection, nPackets, mySniffer.missedPackets),
+                sys.stdout.flush()
 
 
 if __name__ == '__main__':
@@ -199,10 +209,7 @@ if __name__ == '__main__':
         else:
             print "ERROR: Could not find the selected device"
 
-        # Dump packets
-        while True:
-            dumpPackets()
-            time.sleep(1)
+        loop()
 
         # Close gracefully
         mySniffer.doExit()


### PR DESCRIPTION
Wireshark supports pipes natively now as of 2.3
https://devzone.nordicsemi.com/question/79845/nrf-sniffer-support-for-wireshark-v203/

> For the "simple user" with NRFsniffer1.0.1 here is a basic help on how to use wireshark 2.3.0 or more (note it will be simplified if Nordic does an update of it's nRFsniffer):
> 
> open the sniffer
> open wireshark
> go to capture->options->manage interfaces...->pipes
> add \\.\pipe\wireshark_nordic_ble in the field
> press OK and start the capture on this interface (for me I have to press several times for it to work)
> For the first time only you open Wireshark:
> 
> go to edit->preferences->protocols->DLT_USER
> edit the encapsulation table and add "user10 (DLT=157)" with "nordic_ble" in payload protocol field.
> 

@Cdealti implemented pipes in his fork https://github.com/cdealti/Adafruit_BLESniffer_Python/ but overwrote the logging so I figured you wouldn't take it as a PR.  I kept his cleaner reporting (which I can remove if its a dealbreaker) and brought in his pipe work as an argument. I could see disabling file logging if you enable pipe, but I left it for now.

Looks like this now with verbosity off
```
Jacobs-MacBook-Air:Adafruit_BLESniffer_Python jacobrosenthal$ python sniffer.py /dev/tty.usbmodem1411 -p
Capturing data to logs/capture.pcap
Connecting to sniffer on /dev/tty.usbmodem1411
Scanning for BLE devices (5s) ...
Found 8 BLE devices:

  [1] "" (00:22:D0:2A:E4:A3, RSSI = -64)
  [2] "" (33:B2:5F:DA:48:D6, RSSI = -103)
  [3] "" (B0:03:4B:F1:75:F3, RSSI = -50)
  [4] "" (D0:03:4B:45:EC:F1, RSSI = -103)
  [5] "" (D0:03:4B:31:75:F2, RSSI = -103)
  [6] "" (0B:F2:C4:87:78:2C, RSSI = -103)
  [7] "" (F8:B2:3F:43:6E:F3, RSSI = -100)
  [8] "oura_0_E32000D86085" (E3:20:00:D8:60:85, RSSI = -84)

Select a device to sniff, or '0' to scan again
> 1
Attempting to follow device 00:22:D0:2A:E4:A3
Pipe ready, run: wireshark -Y btle -k -i /Users/jacobrosenthal/Downloads/Adafruit_BLESniffer_Python/logs/ble.pipe
connected: False, packets: 2695, missed: 0
```